### PR TITLE
Build releases with Github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           path: pyinstaller_builds/dist/
           if-no-files-found: 'error'
   release:
-    # if: github.ref_type == 'tag'
+    if: github.ref_type == 'tag'
     name: Upload release artifacts
     runs-on: ubuntu-latest
     needs: Build
@@ -39,9 +39,6 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           pattern: PyCurveBug*
-      - name: Dump the tree
-        run: |
-          find . -type f
       - name: Upload distribution
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,7 @@ jobs:
     name: Build
     strategy:
       matrix:
-        # os: [ubuntu-latest, windows-latest, macos-latest]
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,20 @@ jobs:
           name: PyCurveBug-build-${{ matrix.os }}
           path: pyinstaller_builds/dist/PyCurveBug-*/*
           if-no-files-found: 'error'
+  release:
+    if: github.ref_type == 'tag'
+    name: Upload release artifacts
+    runs-on: ubuntu-latest
+    needs: Build
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: PyCurveBug*
+      - name: Upload distribution
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ github.ref_name }}" **/PyCurveBug-*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,4 +43,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload "${{ github.ref_name }}" PyCurveBug-build-*/PyCurveBug-*.*tar* --clobber
+          gh release upload "${{ github.ref_name }}" PyCurveBug-build-*/PyCurveBug-*.tar.gz
+          gh release upload "${{ github.ref_name }}" PyCurveBug-build-*/PyCurveBug-*.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
       - name: Install MaOS deps
-        if: ${{ matrix.os == 'Darwin' }}
+        if: ${{ matrix.os == 'macos-latest' }}
         run: brew install sdl2 sdl2_image sdl2_mixer sdl2_ttf pkg-config
       - name: Install python dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,4 +46,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload "${{ github.ref_name }}" PyCurveBug-build-*/PyCurveBug-*.(zip|tar\.gz) --clobber
+          gh release upload "${{ github.ref_name }}" PyCurveBug-build-*/PyCurveBug-*.* --clobber

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,8 @@ jobs:
     name: Build
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        # os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,5 +10,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
       - name: Build on ${{ matrix.os }}
         run: python3 pyinstaller_builds/build.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,5 +17,5 @@ jobs:
           pip install -r requirements.txt
       - name: Build on ${{ matrix.os }}
         run: |
-          ct pyinstaller_builds
+          cd pyinstaller_builds
           python3 build.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,5 +24,6 @@ jobs:
           python3 build.py
       - uses: actions/upload-artifact@v4
         with:
-          path: pyinstaller_builds/dist/PyCurveBug-*.*
+          name: PyCurveBug-build-${{ matrix.os }}
+          path: pyinstaller_builds/dist/PyCurveBug-*/*
           if-no-files-found: 'error'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
       - name: Install MaOS deps
-        run: brew install pygame
+        run: brew install sdl2 sdl2_image sdl2_mixer sdl2_ttf pkg-config
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          python3 -m pip install --upgrade pip
+          pip3 install -r requirements.txt
       - name: Build on ${{ matrix.os }}
         run: |
           cd pyinstaller_builds

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         # os: [ubuntu-latest, windows-latest, macos-latest]
-        os: [ubuntu-latest, windows-latest]
+        os: [macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,14 @@
+name: ci
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  build:
+    name: Build
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build on ${{ matrix.os }}
+        run: python3 pyinstaller_builds/build.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           path: pyinstaller_builds/dist/PyCurveBug-*/*
           if-no-files-found: 'error'
   release:
-    if: github.ref_type == 'tag'
+    # if: github.ref_type == 'tag'
     name: Upload release artifacts
     runs-on: ubuntu-latest
     needs: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,5 +24,5 @@ jobs:
           python3 build.py
       - uses: actions/upload-artifact@v4
         with:
-          path: dist/PyCurveBug-*.*
+          path: dist/PyCurveBug-*
           if-no-files-found: 'error'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,4 +16,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
       - name: Build on ${{ matrix.os }}
-        run: python3 pyinstaller_builds/build.py
+        run: |
+          ct pyinstaller_builds
+          python3 build.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,4 +43,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload "${{ github.ref_name }}" **/PyCurveBug-*
+          gh release upload "${{ github.ref_name }}" **/PyCurveBug-*/PyCurveBug-*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,7 @@ jobs:
         run: |
           find . -type f
       - name: Upload distribution
-        if: False  # Disable automatic upload for now
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload "${{ github.ref_name }}" PyCurveBug-build-*/PyCurveBug-*
+          gh release upload "${{ github.ref_name }}" PyCurveBug-build-*/PyCurveBug-*.(zip|tar\.gz) --clobber

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
       - name: Install MaOS deps
-        run: brew install sdl2 sdl2_image sdl2_mixer sdl2_ttf pkg-config
+        run: brew install --with-python3 pygame
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           pattern: PyCurveBug*
+      - name: Dump the tree
+        run: |
+          find . -type f
       - name: Upload distribution
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,7 @@ jobs:
         run: |
           cd pyinstaller_builds
           python3 build.py
+      - uses: actions/upload-artifact@v4
+        with:
+          path: dist/PyCurveBug-*.*
+          if-no-files-found: 'error'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,4 +43,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload "${{ github.ref_name }}" PyCurveBug-build-*/PyCurveBug-*.* --clobber
+          gh release upload "${{ github.ref_name }}" PyCurveBug-build-*/PyCurveBug-*.*tar* --clobber

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+      - name: Install MaOS deps
+        run: brew install sdl2 sdl2_image sdl2_mixer sdl2_ttf pkg-config
       - name: Build on ${{ matrix.os }}
         run: |
           cd pyinstaller_builds

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
       - uses: actions/setup-python@v5
       - name: Install MaOS deps
         run: brew install sdl2 sdl2_image sdl2_mixer sdl2_ttf pkg-config
-      - name: Install dependencies
+      - name: Install python dependencies
         run: |
-          python3 -m pip install --upgrade pip
-          pip3 install -r requirements.txt
+          python3 -m pip install --break-system-packages --upgrade pip
+          pip3 install --break-system-packages -r requirements.txt
       - name: Build on ${{ matrix.os }}
         run: |
           cd pyinstaller_builds

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,13 @@ jobs:
     name: Build
     strategy:
       matrix:
-        # os: [ubuntu-latest, windows-latest, macos-latest]
-        os: [macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
       - name: Install MaOS deps
+        if: ${{ matrix.os == 'Darwin' }}
         run: brew install sdl2 sdl2_image sdl2_mixer sdl2_ttf pkg-config
       - name: Install python dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,4 +43,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload "${{ github.ref_name }}" **/PyCurveBug/PyCurveBug-*/PyCurveBug-*
+          gh release upload "${{ github.ref_name }}" PyCurveBug-build-*/PyCurveBug-*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
       - name: Install MaOS deps
-        run: brew install --with-python3 pygame
+        run: brew install pygame
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
+      - name: Install MaOS deps
+        run: brew install sdl2 sdl2_image sdl2_mixer sdl2_ttf pkg-config
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-      - name: Install MaOS deps
-        run: brew install sdl2 sdl2_image sdl2_mixer sdl2_ttf pkg-config
       - name: Build on ${{ matrix.os }}
         run: |
           cd pyinstaller_builds

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: PyCurveBug-build-${{ matrix.os }}
-          path: pyinstaller_builds/dist/PyCurveBug-*/*
+          path: pyinstaller_builds/dist/
           if-no-files-found: 'error'
   release:
     # if: github.ref_type == 'tag'
@@ -43,6 +43,7 @@ jobs:
         run: |
           find . -type f
       - name: Upload distribution
+        if: False  # Disable automatic upload for now
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,8 @@ jobs:
     name: Build
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        # os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,4 +43,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload "${{ github.ref_name }}" **/PyCurveBug-*/PyCurveBug-*
+          gh release upload "${{ github.ref_name }}" **/PyCurveBug/PyCurveBug-*/PyCurveBug-*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,5 +24,5 @@ jobs:
           python3 build.py
       - uses: actions/upload-artifact@v4
         with:
-          path: pyinstaller_builds/dist/PyCurveBug-*
+          path: pyinstaller_builds/dist/PyCurveBug-*.*
           if-no-files-found: 'error'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,5 +24,5 @@ jobs:
           python3 build.py
       - uses: actions/upload-artifact@v4
         with:
-          path: dist/PyCurveBug-*
+          path: pyinstaller_builds/dist/PyCurveBug-*
           if-no-files-found: 'error'

--- a/pyinstaller_builds/build.py
+++ b/pyinstaller_builds/build.py
@@ -21,8 +21,8 @@ class BuildConfig:
     AUTHOR = "Robert Valentine"
 
     # Source files
-    MAIN_SCRIPT = "PyCurveBug.py"
-    CONFIG_FILE = "curvebug_config.json"
+    MAIN_SCRIPT = "../PyCurveBug.py"
+    CONFIG_FILE = "../curvebug_config.json"
 
     # Build directories
     BUILD_DIR = "build"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+
+# The latest versions should be fine
+pygame
+pyserial
+numpy
+pyinstaller

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 
 # The latest versions should be fine
-pygame; sys_platform == "linux"
+pygame
 pyserial
 numpy
 pyinstaller

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,8 @@
 
 # The latest versions should be fine
+if platform.system() == 'Linux':
+  pygame
+
 pyserial
 numpy
 pyinstaller

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 
 # The latest versions should be fine
-pygame
 pyserial
 numpy
 pyinstaller

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,6 @@
 
 # The latest versions should be fine
-if platform.system() == 'Linux':
-  pygame
-
+pygame; sys_platform == "linux"
 pyserial
 numpy
 pyinstaller


### PR DESCRIPTION
This is not yet fit for use, but the principle is sound. Github provides actions as a free service for OSS projects, and this can be used to build releases for Linux, Windows and MacOS.
See an example here: https://github.com/sigurasg/PyCurveBug/releases/tag/v1.0.1rc3.
I don't have a CurveBug, so I can't say whether these releases work right - can you test the Windows one?